### PR TITLE
Config nits

### DIFF
--- a/core/options.py
+++ b/core/options.py
@@ -9,16 +9,16 @@ class Options:
     # Unet image input size
     input_size: int = 256
     # Unet definition
-    down_channels: Tuple[int] = (64, 128, 256, 512, 1024, 1024)
-    down_attention: Tuple[bool] = (False, False, False, True, True, True)
+    down_channels: Tuple[int, ...] = (64, 128, 256, 512, 1024, 1024)
+    down_attention: Tuple[bool, ...] = (False, False, False, True, True, True)
     mid_attention: bool = True
-    up_channels: Tuple[int] = (1024, 1024, 512, 256)
-    up_attention: Tuple[bool] = (True, True, True, False)
+    up_channels: Tuple[int, ...] = (1024, 1024, 512, 256)
+    up_attention: Tuple[bool, ...] = (True, True, True, False)
     # Unet output size, dependent on the input_size and U-Net structure!
     splat_size: int = 64
     # gaussian render size
     output_size: int = 256
-    
+
     ### dataset
     # data mode (only support s3 now)
     data_mode: Literal['s3'] = 's3'
@@ -40,7 +40,7 @@ class Options:
     ### training
     # workspace
     workspace: str = './workspace'
-    # resume 
+    # resume
     resume: Optional[str] = None
     # batch size (per-GPU)
     batch_size: int = 8

--- a/core/unet.py
+++ b/core/unet.py
@@ -3,10 +3,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import numpy as np
-from typing import Tuple, Optional, Literal
+from typing import Tuple, Literal
 from functools import partial
 
-from core.attention import MemEffAttention, MemEffCrossAttention
+from core.attention import MemEffAttention
 
 class MVAttention(nn.Module):
     def __init__(
@@ -236,11 +236,11 @@ class UNet(nn.Module):
         self,
         in_channels: int = 3,
         out_channels: int = 3,
-        down_channels: Tuple[int] = (64, 128, 256, 512, 1024),
-        down_attention: Tuple[bool] = (False, False, False, True, True),
+        down_channels: Tuple[int, ...] = (64, 128, 256, 512, 1024),
+        down_attention: Tuple[bool, ...] = (False, False, False, True, True),
         mid_attention: bool = True,
-        up_channels: Tuple[int] = (1024, 512, 256),
-        up_attention: Tuple[bool] = (True, True, False),
+        up_channels: Tuple[int, ...] = (1024, 512, 256),
+        up_attention: Tuple[bool, ...] = (True, True, False),
         layers_per_block: int = 2,
         skip_scale: float = np.sqrt(0.5),
     ):


### PR DESCRIPTION
Hi, thanks for the super cool work!! The results look awesome, and it's cool to see `tyro` being used.

As a minor fix, `Tuple[int]` corresponds to a length-1 tuple; a variable-length tuple can be written as `Tuple[int, ...]`: https://docs.python.org/3/library/typing.html#annotating-tuples

This will impact the generated CLI's behavior.